### PR TITLE
ci: add msvc upload

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -209,9 +209,8 @@ jobs:
         with:
           name: keeperfx-windows-x64-msvc-debug
           path: |
-            out/build/x64-windows-static-debug/keeperfx*.exe
-            out/build/x64-windows-static-debug/*.pdb
-            out/build/x64-windows-static-debug/*.map
+            .deploy/keeperfx*.exe
+            .deploy/*.pdb
           if-no-files-found: warn
 
   summary:


### PR DESCRIPTION
This pull request updates the artifact paths for the Windows x64 MSVC debug build in the GitHub Actions workflow. The new configuration changes where build artifacts are collected from, ensuring consistency with the deployment output directory.

**CI/CD Workflow Improvements:**

* Updated the artifact paths in `.github/workflows/ci-build.yml` for the `keeperfx-windows-x64-msvc-debug` job to collect `.exe` and `.pdb` files from the `.deploy` directory instead of `out/build/x64-windows-static-debug`, and removed the `.map` file from the collected artifacts.